### PR TITLE
Enhance update_server view to handle GitHub webhook for main branch p…

### DIFF
--- a/views.py
+++ b/views.py
@@ -6,8 +6,20 @@ import json
 @csrf_exempt
 def update_server(request):
     if request.method == "POST":
-        repo = git.Repo('/home/mauroleao1/bookstore')
-        origin = repo.remotes.origin
-        origin.pull()
-        return HttpResponse("Atualizado com sucesso!")
-    return HttpResponse("Aguardando requisição POST do GitHub")
+        # Parse the GitHub webhook payload
+        payload = json.loads(request.body)
+        
+        # Check if this is a push to the main branch
+        if payload.get('ref') == 'refs/heads/main':
+            repo = git.Repo('/home/mauroleao1/bookstore')
+            origin = repo.remotes.origin
+            
+            # Fetch and pull the latest changes
+            origin.fetch()
+            origin.pull()
+            
+            return HttpResponse("Código atualizado com sucesso!", status=200)
+            
+        return HttpResponse("Evento recebido mas não é um push para main", status=200)
+        
+    return HttpResponse("Esperando POST do GitHub", status=200)


### PR DESCRIPTION
This pull request includes updates to the `update_server` function in `views.py` to handle GitHub webhook payloads more effectively. The most important changes include parsing the webhook payload, checking for pushes to the main branch, and providing more specific HTTP responses.

Enhancements to webhook handling:

* [`views.py`](diffhunk://#diff-890c5ae477b80bb93bc92e85762014565e9870d33259b58781cd649a6f1e7080R9-R25): Added code to parse the GitHub webhook payload and check if the push event is to the main branch.
* [`views.py`](diffhunk://#diff-890c5ae477b80bb93bc92e85762014565e9870d33259b58781cd649a6f1e7080R9-R25): Modified the function to fetch and pull the latest changes from the repository when a push to the main branch is detected.
* [`views.py`](diffhunk://#diff-890c5ae477b80bb93bc92e85762014565e9870d33259b58781cd649a6f1e7080R9-R25): Updated HTTP responses to provide more specific feedback based on the type of event received.…ushes