### PR TITLE
Rename update server URL path for clarity

### DIFF
--- a/bookstore/urls.py
+++ b/bookstore/urls.py
@@ -25,6 +25,6 @@ urlpatterns = [
     re_path("bookstore/(?P<version>(v1|v2))/", include("order.urls")),
     re_path("bookstore/(?P<version>(v1|v2))/", include("product.urls")),
     path("api-token-auth/", obtain_auth_token, name="api_token_auth"),
-    path("update_server/", views.update, name="update"),
+    path("update_server/", views.update, name="update_server"),
     path('hello/', views.hello_world, name='hello_world'),
 ]


### PR DESCRIPTION
This pull request includes a small change to the `bookstore/urls.py` file. The change corrects the name of the `update_server` path to ensure consistency.

* [`bookstore/urls.py`](diffhunk://#diff-b3d70e053162f46876ca5bcdd4daacd7bbf44478ebbac340bc035d97a22974e7L28-R28): Changed the name of the `update` path to `update_server` for consistency.